### PR TITLE
Ensure file is saved before and after exporting

### DIFF
--- a/icns-export.jsx
+++ b/icns-export.jsx
@@ -22,10 +22,22 @@
  */
 
 (function () {
-  var doc = app.activeDocument;
+  var doc = null;
+  try {
+    doc = app.activeDocument;
+  } catch (ex) {
+    alert('You must have an active document');
+    return;
+  }
+
   var ab = doc.artboards[0];
   var width = ab.artboardRect[2] - ab.artboardRect[0];
   var height = ab.artboardRect[1] - ab.artboardRect[3];
+
+  if (doc.path == '' || !doc.saved) {
+    alert('You must save your document before exporting it');
+    return;
+  }
 
   if (width != 1024 || height != 1024) {
     alert('Your document has size ' + width + 'x' + height + ' pixels, but must have size 1024x1024 pixels');
@@ -60,6 +72,7 @@
     format.png = readFile(filePng);
     totalLength += format.png.length;
   }
+  doc.save();
 
   openFile(file, 'w');
 


### PR DESCRIPTION
The problem raises from the `Document.exportFile` method that is used to generate the needed PNG files. Did not find another way to create PNGs with exporting.

One workaround to call `Document.save()` after the exporting. This would change the modified state back to unmodified. To ensure that no unwanted stuff is saved, the script now ensures before exporting, that the document is saved.