### PR TITLE
Add new formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,5 @@ This script allows to export icons created in Adobe Illustrator directly to a mu
 
 You can just clone/unpack the `icns-export.jsx` file anywhere to your computer and then run it via `File` > `Scripts` > `Other Script...`. If you want the script to occur in the `Scripts` menu permanently, copy the script file to
 
-* Mac OS: /Applications/Adobe lllustrator CS 6/Presets/[language]/Scripts/
-* Windows: C:\Program Files\Adobe\Adobe lllustratorCS6\Presets[language]\Scripts\
+* Mac OS: /Applications/Adobe lllustrator [year]/Presets/[language]/Scripts/
+* Windows: C:/Program Files/Adobe/Adobe lllustrator [year]/Presets/[language]/Scripts/

--- a/icns-export.jsx
+++ b/icns-export.jsx
@@ -51,14 +51,19 @@
   }
 
   var formats = [
+    // 24-bit rgb icon
     { type: 'is32', size: 16 },
     { type: 'il32', size: 32 },
     { type: 'ih32', size: 48 },
     { type: 'it32', size: 128 },
+
+    // 8-bit mask
     { type: 's8mk', size: 16 },
     { type: 'l8mk', size: 32 },
     { type: 'h8mk', size: 48 },
     { type: 't8mk', size: 128 },
+
+    // Retina
     { type: 'ic04', size: 16 },
     { type: 'ic05', size: 32 },
     { type: 'ic07', size: 128 },

--- a/icns-export.jsx
+++ b/icns-export.jsx
@@ -51,10 +51,16 @@
   }
 
   var formats = [
-    // Quick fix for https://github.com/choffmeister/adobe-illustrator-icnsexport/issues/7
-    // { type: 'icp4', size: 16 },
-    // { type: 'icp5', size: 32 },
-    // { type: 'icp6', size: 64 },
+    { type: 'is32', size: 16 },
+    { type: 'il32', size: 32 },
+    { type: 'ih32', size: 48 },
+    { type: 'it32', size: 128 },
+    { type: 's8mk', size: 16 },
+    { type: 'l8mk', size: 32 },
+    { type: 'h8mk', size: 48 },
+    { type: 't8mk', size: 128 },
+    { type: 'ic04', size: 16 },
+    { type: 'ic05', size: 32 },
     { type: 'ic07', size: 128 },
     { type: 'ic08', size: 256 },
     { type: 'ic09', size: 512 },

--- a/icns-export.jsx
+++ b/icns-export.jsx
@@ -63,17 +63,23 @@
     { type: 'h8mk', size: 48 },
     { type: 't8mk', size: 128 },
 
-    // Retina
+    // Retina @1x
     { type: 'ic04', size: 16 },
+    { type: 'icsb', size: 18 },
+    { type: 'sb24', size: 24 },
     { type: 'ic05', size: 32 },
     { type: 'ic07', size: 128 },
     { type: 'ic08', size: 256 },
     { type: 'ic09', size: 512 },
-    { type: 'ic10', size: 1024 },
+
+    // Retina @2x
     { type: 'ic11', size: 32 },
+    { type: 'icsB', size: 36 },
+    { type: 'SB24', size: 48 },
     { type: 'ic12', size: 64 },
     { type: 'ic13', size: 256 },
-    { type: 'ic14', size: 512 }
+    { type: 'ic14', size: 512 },
+    { type: 'ic10', size: 1024 },
   ]
 
   var totalLength = 0;


### PR DESCRIPTION
I added back the commented out sizes and replaced 64x64 with 48x48 and the 24-bit rgb icons support jpeg and png as well and last the readme paths were updated since they changed since cs6